### PR TITLE
fixing folder does not exist error

### DIFF
--- a/initial-setup.sh
+++ b/initial-setup.sh
@@ -99,7 +99,7 @@ if [ $ERROR -ne 0 ]; then
 fi
 
 echo "Copying certificates to relevant redir and teamserver folders."
-cp ./certs/* ./elkserver/logstash/certs/ >> $LOGFILE 2>&1
+cp -r ./certs ./elkserver/logstash/ >> $LOGFILE 2>&1
 cp ./certs/redelkCA.crt ./teamservers/filebeat/ >> $LOGFILE 2>&1
 cp ./certs/redelkCA.crt ./redirs/filebeat/ >> $LOGFILE 2>&1
 


### PR DESCRIPTION
The folder "./elkserver/logstash/certs/" does not exist so the copy command does not succeed. This will fail later in starting Logstash, because of missing certs. With cp -r of the whole folder this error should be fixed.