### PR TITLE
Fixed typo in EOF notation

### DIFF
--- a/teamservers/install-teamserver.sh
+++ b/teamservers/install-teamserver.sh
@@ -189,7 +189,7 @@ allowscp
 allowsftp
 allowrsync
 user = scponly:011:100110:
-EOF 
+EOF
 fi >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then


### PR DESCRIPTION
Was causing an error because of the ending space