### PR TITLE
"Date" header should be set on outgoing emails

### DIFF
--- a/elkserver/scripts/SendMail.py
+++ b/elkserver/scripts/SendMail.py
@@ -22,6 +22,7 @@ def SendMail(to, mail, subject, fromaddr=config.fromAddr, attachment = "None", s
     msg['Subject'] = subject
     msg['From'] = formataddr((str(Header(fromaddr, 'utf-8')), fromaddr))
     msg['To'] = to
+    msg['Date'] = formatdate()
     #DONE PREPARATION, BUILD MAIL
     msg.attach(MIMEText(html,'html'))
     if attachment != "None":


### PR DESCRIPTION
The "Date" email header should be set to be compliant with RFC 5322.
Some email servers will trigger a warning if this is not the case.