### PR TITLE
Replace rssh with rush

### DIFF
--- a/teamservers/install-teamserver.sh
+++ b/teamservers/install-teamserver.sh
@@ -172,7 +172,7 @@ echo "Creating scponly user"
 grep scponly /etc/passwd > /dev/null
 EXIT=$?
 if [ $EXIT -ne 0  ]; then
-    useradd -m -p $(openssl passwd -1 `head /dev/urandom | tr -dc A-Za-z0-9 | head -c20`) scponly
+    useradd -m -p $(openssl passwd -1 `head /dev/urandom | tr -dc A-Za-z0-9 | head -c20`) -s /usr/sbin/rush scponly
 else
     echo "User scponly already exists"
 fi  >> $LOGFILE 2>&1
@@ -194,27 +194,34 @@ if [ $ERROR -ne 0 ]; then
     echoerror "Could not set ssh key authentication for scponly user (Error Code: $ERROR)."
 fi
 
-echo "Installing rssh"
-apt-get install -y rssh >> $LOGFILE 2>&1
+echo "Installing rush"
+apt-get install -y rush >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
-    echoerror "Could not install rssh (Error Code: $ERROR)."
+    echoerror "Could not install rush (Error Code: $ERROR)."
 fi
 
-echo "Configuring rssh"
-grep scponly /etc/rssh.conf > /dev/null
+echo "Configuring rush"
+grep scponly /etc/rush.rc > /dev/null
 EXIT=$?
 if [ $EXIT -ne 0 ]; then
-    cat << EOF >> /etc/rssh.conf
-allowscp
-allowsftp
-allowrsync
-user = scponly:011:100110:
+    cat << EOF > /etc/rush.rc
+debug 1
+
+rule rsync
+  command ^rsync --server --sender
+  uid >= 1000
+  set[0] /usr/bin/rsync
+  match[$] ^~/.*
+  match[$] ! \.\.
+  transform[$] s,^~/,./,
+  umask 002
+  chdir ~
 EOF
 fi >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
-    echoerror "Could not configure rssh (Error Code: $ERROR)."
+    echoerror "Could not configure rush (Error Code: $ERROR)."
 fi
 
 echo "Creating crontab for local rscync of cobaltstrike logs"


### PR DESCRIPTION
The `rssh` package is no longer available from the repositories in Ubuntu 20.04. An alternative to this seems to be [rush](http://manpages.ubuntu.com/manpages/xenial/man8/rush.8.html). This PR is my attempt at replacing `rssh` with `rush`. Please note I only created a rule for `rsync` as I wasn't able to find any use of `scp` or `sftp` anywhere in the script. Please let me know if I've missed it somewhere.

Sample output:
```
/opt/RedELK-1.1/teamservers# ./install-teamserver.sh 1 2 3
This script will install and configure necessary components for RedELK on Cobalt Strike teamservers
Starting pre installation checks
[!] Filebeat: required version is installed (6.8.2). Should be good. Stopping service now before continuing installation.
Setting timezone
Restarting rsyslog deamon for new timezone to take effect
Adding GPG key of Elastic
Installing apt-transport-https
Adding Elastic APT repository
Updating APT
Installing filebeat ...
Setting filebeat to auto start after reboot
Making backup of original filebeat config
Copying new config file
Copying ca file 
Altering hostname field in filebeat config
Altering attackscenario field in filebeat config 
Altering log destination field in filebeat config 
Starting filebeat
Creating scponly user
Setting ssh key authentication for scponly user
Installing rush
Configuring rush
Creating crontab for local rscync of cobaltstrike logs
Creating RedELK log directory
Copying RedELK background running scripts


Done with setup of RedELK on teamserver.
```
```
rsync -axv -e 'ssh -o "StrictHostKeyChecking=no" -i keys/testproject-test-1' scponly@192.168.1.142:~/downloads /tmp/downloads
receiving incremental file list
downloads/

sent 28 bytes  received 77 bytes  70.00 bytes/sec
total size is 0  speedup is 0.00
```
```
rsync -axv -e 'ssh -o "StrictHostKeyChecking=no" -i keys/testproject-test-1' scponly@192.168.1.142:/etc/passwd /tmp/downloads
You are not permitted to execute this command.
Contact the systems administrator for further assistance.
rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]
rsync error: error in rsync protocol data stream (code 12) at io.c(235) [Receiver=3.1.3]
```
```
ssh scponly@192.168.1.142 -i keys/testproject-test-1 
Welcome to Ubuntu 20.04 LTS (GNU/Linux 5.4.0-42-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Thu Jul 30 10:03:46 CEST 2020

  System load:  0.13              Users logged in:         1
  Usage of /:   8.4% of 56.33GB   IPv4 address for ens192: 192.168.1.142
  Memory usage: 8%                IPv4 address for tun0:   10.100.0.2
  Swap usage:   0%                IPv4 address for tun1:   10.100.1.2
  Processes:    186


61 updates can be installed immediately.
0 of these updates are security updates.
To see these additional updates run: apt list --upgradable


Last login: Thu Jul 30 09:50:48 2020 from 192.168.0.12
You do not have interactive login access to this machine.
Contact the systems administrator for further assistance.

Connection to 192.168.1.142 closed.
```