### PR TITLE
Update redelk-redir-nginx.conf

### DIFF
--- a/example-data-and-configs/nginx/redelk-redir-nginx.conf
+++ b/example-data-and-configs/nginx/redelk-redir-nginx.conf
@@ -11,13 +11,13 @@ events {
 http {
 
 	# Create variable, can't use $hostname as it is a known variable in nginx
-	map $redir_hostname $redir_hostname { 
+	map $host $redir_hostname { 
 		default "www.example.com";
 	}
-	map $backend_name $backend_name { 
+	map $host $backend_name { 
 		default "decoy";
 	}
-	map $frontend_name $frontend_name { 
+	map $host $frontend_name { 
 		default "example-www";
 	}
 


### PR DESCRIPTION
changed $variable to $host so that cycling errors in error.log will be resolved. $host is just a placeholder, regardless of the value in $host, the default value will be assigned to $redir_hostname, $backend_name or $frontend_name as no other value is defined.Unless there is a "set variable value" in the block, then the set statement will take precedence. 