### PR TITLE
Fix search with free text

### DIFF
--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_implantsdb.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_implantsdb.json
@@ -873,7 +873,7 @@
             "number_of_replicas": "0",
             "number_of_shards": "1",
             "query": {
-                "default_field": []
+                "default_field": "*"
             },
             "refresh_interval": "5s"
         }

--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_redirtraffic.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_redirtraffic.json
@@ -731,7 +731,7 @@
             "number_of_replicas": "0",
             "number_of_shards": "1",
             "query": {
-                "default_field": []
+                "default_field": "*"
             },
             "refresh_interval": "5s"
         }

--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_rtops.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_rtops.json
@@ -790,7 +790,7 @@
             "number_of_replicas": "0",
             "number_of_shards": "1",
             "query": {
-                "default_field": []
+                "default_field": "*"
             },
             "refresh_interval": "5s"
         }


### PR DESCRIPTION
This PR allows to search for data in every fields using free text (fixes #103)

Please note that this will only work for indices created after having changed the index template. Previously created indices will still have the `[]` value.