### PR TITLE
Add new CS4.2 fields in ES template

### DIFF
--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_implantsdb.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_implantsdb.json
@@ -873,7 +873,7 @@
             "number_of_replicas": "0",
             "number_of_shards": "1",
             "query": {
-                "default_field": []
+                "default_field": "*"
             },
             "refresh_interval": "5s"
         }

--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_redirtraffic.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_redirtraffic.json
@@ -731,7 +731,7 @@
             "number_of_replicas": "0",
             "number_of_shards": "1",
             "query": {
-                "default_field": []
+                "default_field": "*"
             },
             "refresh_interval": "5s"
         }

--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_rtops.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_rtops.json
@@ -790,7 +790,7 @@
             "number_of_replicas": "0",
             "number_of_shards": "1",
             "query": {
-                "default_field": []
+                "default_field": "*"
             },
             "refresh_interval": "5s"
         }

--- a/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_rtops.json
+++ b/elkserver/docker/redelk-base/redelkinstalldata/templates/redelk_elasticsearch_template_rtops.json
@@ -117,6 +117,12 @@
                     "message": {
                         "type": "text"
                     },
+                    "operator": {
+                        "type": "keyword"
+                    },
+                    "operator_ip": {
+                        "type": "ip"
+                    },
                     "program": {
                         "type": "keyword"
                     },
@@ -548,7 +554,13 @@
             },
             "keystrokes": {
                 "properties": {
+                    "desktop_session": {
+                        "type": "keyword"
+                    },
                     "url": {
+                        "type": "keyword"
+                    },
+                    "user": {
                         "type": "keyword"
                     }
                 },
@@ -673,10 +685,19 @@
             },
             "screenshot": {
                 "properties": {
+                    "desktop_session": {
+                        "type": "keyword"
+                    },
+                    "file_name": {
+                        "type": "keyword"
+                    },
                     "full": {
                         "type": "keyword"
                     },
                     "thumb": {
+                        "type": "keyword"
+                    },
+                    "title": {
                         "type": "keyword"
                     }
                 },

--- a/helper-scripts/export_kibana_config.py
+++ b/helper-scripts/export_kibana_config.py
@@ -12,7 +12,7 @@ from pprint import pprint
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-SCHEME = 'http'
+SCHEME = 'https'
 KIBANA_URL = SCHEME + '://localhost:5601'
 KIBANA_USER = 'redelk'
 KIBANA_PASS = 'redelk'
@@ -21,7 +21,7 @@ REDELK_OBJ_FILTER = 'RedELK'
 INDEX_PATTERNS_FILTER = 'rtops|redirtraffic|implantsdb|bluecheck|credentials|email|.siem-signals'
 EXPORT_FILES_PREFIX_KIBANA = 'redelk_kibana_'
 ES_URL = SCHEME + '://localhost:9200'
-ES_TEMPLATES_LIST = [ 'rtops', 'redirtraffic', 'implantsdb', 'bluecheck' ]
+ES_TEMPLATES_LIST = [ 'rtops', 'redirtraffic', 'implantsdb', ] #'bluecheck' ]
 EXPORT_FILES_PREFIX_ES = 'redelk_elasticsearch_'
 DIFF_PATH = 'diff/' # path is relative to exportpath
 


### PR DESCRIPTION
This PR adds the new CS4.2 missing fields in `rtops` ES index template. (fixes #110 )