### PR TITLE
logstash email index fields renaming

### DIFF
--- a/elkserver/docker/redelk-logstash/redelkinstalldata/redelk-main/conf.d/12-input_email_logstash.conf
+++ b/elkserver/docker/redelk-logstash/redelkinstalldata/redelk-main/conf.d/12-input_email_logstash.conf
@@ -30,9 +30,9 @@ input {
   #  check_interval => 180
   #  folder => "Inbox"
   #  uid_tracking => "true"
-  #  add_field => { "infralogtype" => "email" }
-  #  add_field => { "attackscenario" => "test" }
-  #  add_field => { "emailfolder" => "inbox" }
+  #  add_field => { "infra.log.type" => "email" }
+  #  add_field => { "infra.attack_scenario" => "test" }
+  #  add_field => { "email_folder" => "inbox" }
   #  strip_attachments => "true" # we have to strip attachments for now because of a stupid bug in Logstash
   #}
   ## Outlook.com Sent
@@ -44,9 +44,9 @@ input {
   #  check_interval => 180
   #  folder => "Sent"
   #  uid_tracking => "true"
-  #  add_field => { "infralogtype" => "email" }
-  #  add_field => { "attackscenario" => "test" }
-  #  add_field => { "emailfolder" => "sent" }
+  #  add_field => { "infra.log.type" => "email" }
+  #  add_field => { "infra.attack_scenario" => "test" }
+  #  add_field => { "email_folder" => "sent" }
   #  strip_attachments => "true" # we have to strip attachments for now because of a stupid bug in Logstash
   #}
   ## Gmail.com Inbox
@@ -58,9 +58,9 @@ input {
   #  check_interval => 180
   #  folder => "Inbox"
   #  uid_tracking => "true"
-  #  add_field => { "infralogtype" => "email" }
-  #  add_field => { "attackscenario" => "test" }
-  #  add_field => { "emailfolder" => "inbox" }
+  #  add_field => { "infra.log.type" => "email" }
+  #  add_field => { "infra.attack_scenario" => "test" }
+  #  add_field => { "email_folder" => "inbox" }
   #  strip_attachments => "true" # we have to strip attachments for now because of a stupid bug in Logstash
   #}
   ## Gmail.com Sent
@@ -72,9 +72,9 @@ input {
   #  check_interval => 180
   #  folder => "[Gmail]/Sent Mail"
   #  uid_tracking => "true"
-  #  add_field => { "infralogtype" => "email" }
-  #  add_field => { "attackscenario" => "test" }
-  #  add_field => { "emailfolder" => "sent" }
+  #  add_field => { "infra.log.type" => "email" }
+  #  add_field => { "infra.attack_scenario" => "test" }
+  #  add_field => { "email_folder" => "sent" }
   #  strip_attachments => "true" # we have to strip attachments for now because of a stupid bug in Logstash
   #}
 }

--- a/elkserver/docker/redelk-logstash/redelkinstalldata/redelk-main/conf.d/30-filter-email_logstash.conf
+++ b/elkserver/docker/redelk-logstash/redelkinstalldata/redelk-main/conf.d/30-filter-email_logstash.conf
@@ -1,6 +1,6 @@
 # Part of RedELK
 #
-# In this file we configure the logstash filtes for Apache logs
+# In this file we configure the logstash filters for email inputs
 #
 # Author: Outflank B.V. / Marc Smeets
 #


### PR DESCRIPTION
Logstash filters for email input was still using pre ECS naming. This PR fixes this.