### PR TITLE
Update getremotelogs.sh to accept custom a SSH port

### DIFF
--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -13,7 +13,7 @@ if [ $# -lt 3 ] ; then
     echo "[X] Error - need IP or full DNS name of system to get remote logs from as 1st parameter."
     echo "[X] Error - need the remote system's filebeats hostname as 2nd parameter."
     echo "[X] Error - need the username to connect with as 3rd parameter."
-    echo "[X] Error - need the ssh port of system to get remote logs from as 4th parameter. Defaults to '22'."
+    echo "[X] Optional - need the remote system's ssh port to get logs as 4th parameter. Defaults to '22'"
     echo "Incorrect amount of parameters" >> $LOGFILE 2>&1
     exit 1
 fi

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -13,7 +13,7 @@ if [ $# -lt 3 ] ; then
     echo "[X] Error - need IP or full DNS name of system to get remote logs from as 1st parameter."
     echo "[X] Error - need the remote system's filebeats hostname as 2nd parameter."
     echo "[X] Error - need the username to connect with as 3rd parameter."
-    echo "[X] Error - need the ssh port of system to get remote logs from 4rd parameter. Defaults to '22'."
+    echo "[X] Error - need the ssh port of system to get remote logs from 4th parameter. Defaults to '22'."
     echo "Incorrect amount of parameters" >> $LOGFILE 2>&1
     exit 1
 fi

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -13,14 +13,15 @@ if ! [ $# -eq 3 ] ; then
     echo "[X] Error - need IP or full DNS name of system to get remote logs from as 1st parameter."
     echo "[X] Error - need the remote system's filebeats hostname as 2nd parameter."
     echo "[X] Error - need the username to connect with as 3rd parameter."
+    echo "[X] Error - need the ssh port of system to get remote logs from 4rd parameter. Defaults to '22'."
     echo "Incorrect amount of parameters" >> $LOGFILE 2>&1
     exit 1
 fi
-mkdir -p /var/www/html/c2logs/$2 >> $LOGFILE 2>&1
+mkdir -p /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
 
-echo "`date` ######## Start of rsync to $1" >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' $3@$1:~/logs /var/www/html/c2logs/$2 >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' $3@$1:~/downloads /var/www/html/c2logs/$2 >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' $3@$1:~/profiles /var/www/html/c2logs/$2 >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' $3@$1:~/data /var/www/html/c2logs/$2 >> $LOGFILE 2>&1
-echo "`date` ######## Done with rsync" >> $LOGFILE 2>&1
+echo "$(date) ######## Start of rsync to $1" >> $LOGFILE 2>&1
+rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":~/logs /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
+rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":~/downloads /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
+rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":~/profiles /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
+rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":~/data /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
+echo "$(date) ######## Done with rsync" >> $LOGFILE 2>&1

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -13,7 +13,7 @@ if [ $# -lt 3 ] ; then
     echo "[X] Error - need IP or full DNS name of system to get remote logs from as 1st parameter."
     echo "[X] Error - need the remote system's filebeats hostname as 2nd parameter."
     echo "[X] Error - need the username to connect with as 3rd parameter."
-    echo "[X] Error - need the ssh port of system to get remote logs from 4th parameter. Defaults to '22'."
+    echo "[X] Error - need the ssh port of system to get remote logs from as 4th parameter. Defaults to '22'."
     echo "Incorrect amount of parameters" >> $LOGFILE 2>&1
     exit 1
 fi

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -9,7 +9,7 @@
 
 LOGFILE="/var/log/redelk/getremotelogs.log"
 
-if ! [ $# -eq 3 ] ; then
+if [ $# -lt 3 ] ; then
     echo "[X] Error - need IP or full DNS name of system to get remote logs from as 1st parameter."
     echo "[X] Error - need the remote system's filebeats hostname as 2nd parameter."
     echo "[X] Error - need the username to connect with as 3rd parameter."


### PR DESCRIPTION
Hi!

Before anything else, thank you for RedELK! It's been a much welcome addition to and an essential part of our workflow.

This PR adds an SSH port argument to the `getremotelogs.sh` script that defaults to `22`.

Due to how our lab is structured, we have been using a custom version of RedELK where the teamserver pushes the logs. We finally decided to update our team server setup to match RedELK instead, but we can't use a standard SSH port for the `getremotelogs.sh` script.

I can undo the style changes if necessary. They were mostly to quiet down shellcheck. 

Regarding the argument count check, I didn't see an issue with passing too many arguments, so opted for a `less than` check to make the SSH port argument optional. Please correct me if I'm wrong.


