### PR TITLE
Revert neo4j changes

### DIFF
--- a/elkserver/mounts/nginx-config/full.location-conf.template
+++ b/elkserver/mounts/nginx-config/full.location-conf.template
@@ -1,8 +1,8 @@
 location /neo4jbrowser {
-    #return 301 https://$host:7473;
-    auth_basic "Restricted Access";
-    auth_basic_user_file /etc/nginx/conf.d/htpasswd.users;
-    proxy_pass http://redelk-bloodhound:7474/browser;
+    return 301 http://$host:7474;
+    # auth_basic "Restricted Access";
+    # auth_basic_user_file /etc/nginx/conf.d/htpasswd.users;
+    # proxy_pass http://redelk-bloodhound:7474/browser;
 }
 
 location /jupyter {

--- a/elkserver/mounts/nginx-config/full.neo4j-conf.template
+++ b/elkserver/mounts/nginx-config/full.neo4j-conf.template
@@ -1,3 +1,4 @@
+
 upstream neo4j_bolt {
     server redelk-bloodhound:7687;
 }

--- a/elkserver/redelk-dev.yml
+++ b/elkserver/redelk-dev.yml
@@ -162,7 +162,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "7687:7687"
     environment:
       - TLS_NGINX_CRT_PATH=${TLS_NGINX_CRT_PATH}
       - TLS_NGINX_KEY_PATH=${TLS_NGINX_KEY_PATH}
@@ -243,10 +242,9 @@ services:
       - net
     volumes:
       - bloodhound_data:/data
-    expose:
-      - "7687"
     ports:
-      - "7473:7473"
+      - "7474:7474"
+      - "7687:7687"
     environment:
       - NEO4J_AUTH=${NEO4J_AUTH}
       - NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_initial__size}

--- a/elkserver/redelk-full.yml
+++ b/elkserver/redelk-full.yml
@@ -7,7 +7,6 @@
 # - Lorenzo Bernardi (@fastlorenzo)
 #
 
-
 version: "3.3"
 
 networks:
@@ -159,7 +158,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "7687:7687"
     environment:
       - TLS_NGINX_CRT_PATH=${TLS_NGINX_CRT_PATH}
       - TLS_NGINX_KEY_PATH=${TLS_NGINX_KEY_PATH}
@@ -234,10 +232,9 @@ services:
       - net
     volumes:
       - bloodhound_data:/data
-    expose:
-      - "7687"
     ports:
-      - "7473:7473"
+      - "7474:7474"
+      - "7687:7687"
     environment:
       - NEO4J_AUTH=${NEO4J_AUTH}
       - NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_initial__size}


### PR DESCRIPTION
Change back how neo4j is handled to avoid issue with self-signed certificates.

Now redirects HTTP traffic back to `$host:7474` and exposes bolt port (`7687`) from neo4j container.