### PR TITLE
Fix issue 199 wrong paths in rsync

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,9 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8.10'
+        architecture: 'x64'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -29,5 +29,4 @@ jobs:
         pip install -r elkserver/docker/redelk-base/redelkinstalldata/scripts/requirements.txt
     - name: Analysing the code with pylint
       run: |
-        ls -l $(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc;
-        find elkserver/docker/redelk-base/redelkinstalldata/scripts -not -path '*/Chameleon/*' -name '*.py' -print0 | xargs -0 -i sh -c 'echo PYLINTRC = $(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}; PYLINTRC=$(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}'
+        find elkserver/docker/redelk-base/redelkinstalldata/scripts -not -path '*/Chameleon/*' -name '*.py' -print0 | xargs -0 -i sh -c 'echo pylint {}; PYLINTRC=$(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -29,5 +29,5 @@ jobs:
         pip install -r elkserver/docker/redelk-base/redelkinstalldata/scripts/requirements.txt
     - name: Analysing the code with pylint
       run: |
-        echo "PWD: $(pwd)";
-        find elkserver/docker/redelk-base/redelkinstalldata/scripts -not -path '*/Chameleon/*' -name '*.py' -print0 | xargs -0 -i sh -c 'echo pylint {}; PYLINTRC=$(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}'
+        ls -l $(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc;
+        find elkserver/docker/redelk-base/redelkinstalldata/scripts -not -path '*/Chameleon/*' -name '*.py' -print0 | xargs -0 -i sh -c 'echo PYLINTRC = $(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}; PYLINTRC=$(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -29,4 +29,5 @@ jobs:
         pip install -r elkserver/docker/redelk-base/redelkinstalldata/scripts/requirements.txt
     - name: Analysing the code with pylint
       run: |
+        echo "PWD: $(PWD)";
         find elkserver/docker/redelk-base/redelkinstalldata/scripts -not -path '*/Chameleon/*' -name '*.py' -print0 | xargs -0 -i sh -c 'echo pylint {}; PYLINTRC=$(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -29,5 +29,5 @@ jobs:
         pip install -r elkserver/docker/redelk-base/redelkinstalldata/scripts/requirements.txt
     - name: Analysing the code with pylint
       run: |
-        echo "PWD: $(PWD)";
+        echo "PWD: $(pwd)";
         find elkserver/docker/redelk-base/redelkinstalldata/scripts -not -path '*/Chameleon/*' -name '*.py' -print0 | xargs -0 -i sh -c 'echo pylint {}; PYLINTRC=$(pwd)/elkserver/docker/redelk-base/redelkinstalldata/scripts/.pylintrc pylint {}'

--- a/c2servers/scripts/copydownloads_outflankstage1.sh
+++ b/c2servers/scripts/copydownloads_outflankstage1.sh
@@ -9,7 +9,7 @@
 
 LOGFILE="/var/log/redelk/copydownloads.log"
 
-mkdir -p /home/scponly/downloads >> $LOGFILE 2>&1
+mkdir -p /home/scponly/stage1/downloads >> $LOGFILE 2>&1
 
 echo "`date` ######## Start downloads copy" >> $LOGFILE 2>&1
 

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
@@ -12,7 +12,7 @@ Authors:
 import json
 import logging
 
-with open('/etc/redelk/config.json') as json_data:
+with open('/etc/redelk/config.json', encoding='utf-8') as json_data:
     # pylint: disable=invalid-name
     data = json.load(json_data)
 

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/daemon.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/daemon.py
@@ -31,8 +31,7 @@ def load_modules():
         # only take folders and not '__pycache__'
         if os.path.isdir(os.path.join(MODULES_PATH, module_name)) and module_name != '__pycache__':
             try:
-                module = importlib.import_module(
-                    'modules.%s.%s' % (module_name, 'module'))
+                module = importlib.import_module(f'modules.{module_name}.module')
                 if (hasattr(module, 'info') and hasattr(module, 'Module')):
                     module_type = module.info.get('type', None)
                     if module_type == 'redelk_alarm':
@@ -73,11 +72,11 @@ def run_enrichments(enrich_dict):
                     set_tags(enrich_dict[enrich_module]['info']['submodule'], [hit])
 
                 hits = len(enrich_dict[enrich_module]['result']['hits']['hits'])
-                module_did_run(enrich_module, 'enrich', 'success', 'Enriched %s documents' % hits, hits)
+                module_did_run(enrich_module, 'enrich', 'success', f'Enriched {hits} documents', hits)
                 enrich_dict[enrich_module]['status'] = 'success'
             # pylint: disable=broad-except
             except Exception as err:
-                msg = 'Error running enrichment %s: %s' % (enrich_module, err)
+                msg = f'Error running enrichment {enrich_module}: {err}'
                 logger.error(msg)
                 logger.exception(err)
                 module_did_run(enrich_module, 'enrich', 'error', msg)
@@ -96,11 +95,11 @@ def run_alarms(alarm_dict):
                 logger.debug('[a] Running Run() from the Module class in %s', alarm_module)
                 alarm_dict[alarm_module]['result'] = copy.deepcopy(module_class.run())
                 hits = len(alarm_dict[alarm_module]['result']['hits']['hits'])
-                module_did_run(alarm_module, 'alarm', 'success', 'Found %s documents to alarm' % hits, hits)
+                module_did_run(alarm_module, 'alarm', 'success', f'Found {hits} documents to alarm', hits)
                 alarm_dict[alarm_module]['status'] = 'success'
             # pylint: disable=broad-except
             except Exception as error:
-                msg = 'Error running alarm %s: %s' % (alarm_module, error)
+                msg = f'Error running alarm {alarm_module}: {error}'
                 logger.error(msg)
                 logger.exception(error)
                 module_did_run(alarm_module, 'alarm', 'error', msg)

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -21,8 +21,5 @@ fi
 mkdir -p /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
 
 echo "$(date) ######## Start of rsync to $1" >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/logs /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/downloads /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/profiles /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/data /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
+rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/ /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
 echo "$(date) ######## Done with rsync" >> $LOGFILE 2>&1

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/getremotelogs.sh
@@ -21,5 +21,5 @@ fi
 mkdir -p /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
 
 echo "$(date) ######## Start of rsync to $1" >> $LOGFILE 2>&1
-rsync -axv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/ /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
+rsync -rxv -e 'ssh -p '"${4:-22}"' -o "StrictHostKeyChecking=no" -i /home/redelk/.ssh/id_rsa' "$3"@"$1":${5:-"~"}/ /var/www/html/c2logs/"$2" >> $LOGFILE 2>&1
 echo "$(date) ######## Done with rsync" >> $LOGFILE 2>&1

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_backendalarm/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_backendalarm/module.py
@@ -51,7 +51,7 @@ class Module():
     # pylint: disable=no-self-use
     def alarm_check(self):
         """ This check queries for calls to backends that have *alarm* in their name """
-        es_query = 'redir.backend.name:*alarm* AND NOT tags:%s' % (info['submodule'])
+        es_query = f'redir.backend.name:*alarm* AND NOT tags:{info["submodule"]}'
         es_results = get_query(es_query, 10000)
         report = {
             'hits': es_results

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_filehash/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_filehash/module.py
@@ -63,7 +63,7 @@ class Module():
                     'filter': {
                         'range': {
                             'alarm.last_checked': {
-                                'gte': 'now-%ds' % self.interval,
+                                'gte': f'now-{self.interval}s',
                                 'lt': 'now'
                             }
                         }

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_httptraffic/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_httptraffic/module.py
@@ -130,10 +130,10 @@ class Module():
 
         # Now we check if the IPs have already been alarmed in the past timeframe defined in the config
         # pylint: disable=invalid-name
-        for ip in ips:
+        for ip, ip_val in ips.items():
             # Not alarmed yet, process it
             if ip not in alarmed_ips:
-                hits += ips[ip]
+                hits += ip_val
 
         # Return the array of new IP documents to be alarmed
         return hits

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_useragent/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_useragent/module.py
@@ -50,7 +50,7 @@ class Module():
         """ This check queries for UA's that are listed in any blacklist_useragents.conf and do talk to c2* paths on redirectors
         We will dig trough ALL data finding specific IP related lines and tag them reading the useragents we trigger on. """
         file_name = '/etc/redelk/rogue_useragents.conf'
-        with open(file_name) as file:
+        with open(file_name, encoding='utf-8') as file:
             content = file.readlines()
         ua_list = []
         for line in content:
@@ -61,12 +61,12 @@ class Module():
         # add keywords (UA's) to query
         for keyword in keywords:
             if es_subquery == '':
-                es_subquery = '(http.headers.useragent:%s' % keyword
+                es_subquery = f'(http.headers.useragent:{keyword}'
             else:
-                es_subquery = es_subquery + ' OR http.headers.useragent:%s' % keyword
+                es_subquery = es_subquery + f' OR http.headers.useragent:{keyword}'
         es_subquery = es_subquery + ') '
         # q = "%s AND redir.backendname:c2* AND tags:enrich_* AND NOT tags:alarm_* "%qSub
-        es_query = '%s AND redir.backend.name:c2* AND NOT tags:alarm_useragent' % es_subquery
+        es_query = f'{es_subquery} AND redir.backend.name:c2* AND NOT tags:alarm_useragent'
 
         es_results = get_query(es_query, 10000)
         report = {}

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
@@ -70,7 +70,7 @@ class Module():
                 file.read(),
                 Name=filename
             )
-            part['Content-Disposition'] = 'attachment; filename="%s"' % filename
+            part['Content-Disposition'] = f'attachment; filename="{filename}"'
             message.attach(part)
         return message
 
@@ -81,7 +81,7 @@ class Module():
         with open('redelk_white.png', 'rb') as logo_file:
             redelk_logo_b64 = base64.b64encode(logo_file.read()).decode('utf-8')
 
-        mail = '''
+        mail = f'''
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
                 <html xmlns="http://www.w3.org/1999/xhtml">
                     <head>
@@ -89,76 +89,77 @@ class Module():
                         <title>Alarm from RedELK</title>
                         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
                         <style type="text/css">
-                            #normal {
+                            #normal {{
                                 font-family: Tahoma, Geneva, sans-serif;
                                 font-size: 16px;
                                 line-height: 24px;
-                            }
+                            }}
                         </style>
                     </head>
                 <body style="margin: 0; padding: 0;">
                     <table align="center" cellpadding="0" cellspacing="0" width="800" style="border-collapse: collapse;" style="max-width:800px;">
                     <tr>
                         <td bgcolor="#212121" rowspan=2 width="120px" style="padding: 30px 30px 30px 30px; text-align:center;">
-                            <img height="60px" src="data:image/png;base64,%s" alt="img" />
+                            <img height="60px" src="data:image/png;base64,{redelk_logo_b64}" alt="img" />
                         </td>
                         <td bgcolor="#212121" height="30px" style="color: #FAFAFA; font-family: Arial, sans-serif; font-size: 24px; padding: 30px 30px 0px 10px;">
-                            RedELK alarm: <em>%s</em>
+                            RedELK alarm: <em>{alarm["info"]["name"]}</em>
                         </td>
                     </tr>
                     <tr>
                         <td bgcolor="#212121" height="20px" style="color: #FAFAFA; font-family: Arial, sans-serif; font-size: 16px; line-height: 20px; padding: 20px 30px 30px 10px;">
-                            Total hits: <em>%d</em>
+                            Total hits: <em>{alarm["hits"]["total"]}</em>
                         </td>
                     </tr>
                     <tr>
                         <td colspan=2 style="color: #153643; font-family: Arial, sans-serif; font-size: 16px; line-height: 20px; padding: 0px 30px 0px 10px;">
-                            <p>%s</p>
+                            <p>{alarm["info"]["description"]}</p>
                         </td>
                     </tr>
-            ''' % (redelk_logo_b64, alarm['info']['name'], alarm['hits']['total'], alarm['info']['description'])
+            '''
 
-        subject = 'Alarm from %s [%s hits]' % (alarm['info']['name'], alarm['hits']['total'])
+        subject = f'Alarm from {alarm["info"]["name"]} [{alarm["hits"]["total"]} hits]'
 
         if len(alarm['groupby']) > 0:
-            mail += '''
+            mail += f'''
                 <tr>
                     <td colspan=2 style="color: #153643; font-family: Arial, sans-serif; font-size: 12px; line-height: 16px; padding: 0px 15px 0px 15px;">
-                        <p>Please note that the items below have been grouped by: %s</p>
+                        <p>Please note that the items below have been grouped by: {pprint(alarm["groupby"])}</p>
                     </td>
                 </tr>
-                ''' % pprint(alarm['groupby'])
+                '''
 
         try:
             for hit in alarm['hits']['hits']:
                 index = 0
                 title = hit['_id']
                 while index < len(alarm['groupby']):
+                    val = get_value(f'_source.{alarm["groupby"][index]}', hit)
                     if index == 0:
-                        title = get_value('_source.%s' % alarm['groupby'][index], hit)
+                        title = val
                     else:
-                        title = '%s / %s' % (title, get_value('_source.%s' % alarm['groupby'][index], hit))
+                        title = f'{title} / {val}'
                     index += 1
 
-                mail += '''
+                mail += f'''
                     <tr>
                         <td bgcolor="#323232" colspan=2 style="color: #FAFAFA; font-family: Arial, sans-serif; font-size: 16px; line-height: 20px; padding: 10px 10px 10px 10px; text-align:center;">
-                            <b>%s</b>
+                            <b>{title}</b>
                         </td>
                     </tr>
-                    ''' % title
+                    '''
 
                 row = 0
                 for field in alarm['fields']:
                     bgcolor = '#FAFAFA' if row % 2 == 0 else '#F1F1F1'
-                    val = get_value('_source.%s' % field, hit)
+                    val = get_value(f'_source.{field}', hit)
                     value = json2html.convert(json=val)
-                    mail += '''
-                        <tr bgcolor="%s" style="color: #153643; font-family: Arial, sans-serif; font-size: 12px; line-height: 16px;">
-                            <td style="padding: 10px 10px 10px 10px;"><b>%s</b></td>
-                            <td style="padding: 10px 10px 10px 10px; white-space:pre-wrap; word-wrap:break-word">%s</td>
+                    mail += f'''
+                        <tr bgcolor="{bgcolor}" style="color: #153643; font-family: Arial, sans-serif; font-size: 12px; line-height: 16px;">
+                            <td style="padding: 10px 10px 10px 10px;"><b>{field}</b></td>
+                            <td style="padding: 10px 10px 10px 10px; white-space:pre-wrap; word-wrap:break-word">{value}</td>
                         </tr>
-                        ''' % (bgcolor, field, value)
+                        '''
                     row += 1
                 mail += '<tr><td colspan=2 style="padding: 15px;">&nbsp;</td></tr>'
 

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_csbeacon/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_csbeacon/module.py
@@ -47,7 +47,7 @@ class Module():
 
     def enrich_beacon_data(self):
         """ Get all lines in rtops that have not been enriched yet (for CS) """
-        es_query = 'implant.id:* AND c2.program: cobaltstrike AND NOT c2.log.type:implant_newimplant AND NOT tags:%s' % info['submodule']
+        es_query = f'implant.id:* AND c2.program: cobaltstrike AND NOT c2.log.type:implant_newimplant AND NOT tags:{info["submodule"]}'
         not_enriched_results = get_query(es_query, size=10000, index='rtops-*')
 
         # Created a dict grouped by implant ID
@@ -61,14 +61,14 @@ class Module():
 
         hits = []
         # For each implant ID, get the initial beacon line
-        for implant_id in implant_ids:
+        for implant_id, implant_val in implant_ids.items():
             initial_beacon_doc = self.get_initial_beacon_doc(implant_id)
 
             # If not initial beacon line found, skip the beacon ID
             if not initial_beacon_doc:
                 continue
 
-            for doc in implant_ids[implant_id]:
+            for doc in implant_val:
                 # Fields to copy: host.*, implant.*, process.*, user.*
                 res = self.copy_data_fields(initial_beacon_doc, doc, ['host', 'implant', 'user', 'process'])
                 if res:
@@ -78,7 +78,7 @@ class Module():
 
     def get_initial_beacon_doc(self, implant_id):
         """ Get the initial beacon document from cobaltstrike or return False if none found """
-        query = 'implant.id:%s AND c2.program: cobaltstrike AND c2.log.type:implant_newimplant' % implant_id
+        query = f'implant.id:{implant_id} AND c2.program: cobaltstrike AND c2.log.type:implant_newimplant'
         initial_beacon_doc = get_query(query, size=1, index='rtops-*')
         initial_beacon_doc = initial_beacon_doc[0] if len(initial_beacon_doc) > 0 else False
         self.logger.debug('Initial beacon line [%s]: %s', implant_id, initial_beacon_doc)

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_greynoise/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_greynoise/module.py
@@ -95,7 +95,7 @@ class Module():
         hits = []
         # For each IP, get the greynoise data
         # pylint: disable=invalid-name
-        for ip in ips:
+        for ip, ip_val in ips.items():
             # Get data from redirtraffic if within interval
             last_es_data = self.get_last_es_data(ip)
 
@@ -108,7 +108,7 @@ class Module():
             if not greynoise_data:
                 continue
 
-            for doc in ips[ip]:
+            for doc in ip_val:
                 # Fields to copy: greynoise.*
                 es_result = self.add_greynoise_data(doc, greynoise_data)
                 if es_result:
@@ -181,7 +181,7 @@ class Module():
                         {
                             'range':  {
                                 'greynoise.query_timestamp': {
-                                    'gte': 'now-%ss' % self.cache,
+                                    'gte': f'now-{self.cache}s',
                                     'lte': 'now'
                                 }
                             }

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_iplists/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_iplists/module.py
@@ -119,7 +119,7 @@ class Module():
         # 1. Loop through each IP list
         for iplist_name in ip_lists:
             ip_match = []
-            iplist_tag = 'iplist_%s' % iplist_name
+            iplist_tag = f'iplist_{iplist_name}'
 
             #  pylint: disable=invalid-name
             for ip in ip_lists[iplist_name]:

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_tor/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/enrich_tor/module.py
@@ -76,7 +76,7 @@ class Module():
             iplist_es = []
             for ip in iplist_tor:  # pylint: disable=invalid-name
                 if ip != '':
-                    iplist_es.append('%s/32' % ip)
+                    iplist_es.append(f'{ip}/32')
 
             # 2. Delete existing nodes
             es.delete_by_query(index='redelk-*', body={'query': {'bool': {'filter': {'term': {'iplist.name': 'tor'}}}}})

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/helpers.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/helpers.py
@@ -87,7 +87,7 @@ def add_tags_by_query(tags, query, index='redirtraffic-*'):
 
     update_q = {
         'script': {
-            'source': 'ctx._source.tags.add([%s])' % tags_string,
+            'source': f'ctx._source.tags.add([{tags_string}])',
             'lang': 'painless'
         },
         'query': query
@@ -133,11 +133,11 @@ def set_checked_date(doc):
 def group_hits(hits, groupby, res=None):
     """ Takes a list of hits and a list of field names (dot notation) and returns a grouped list """
     if len(groupby) > 0:
-        hits_list = dict()
+        hits_list = {}
         # First time in the loop
         if res is None:
             for hit in hits:
-                value = get_value('_source.%s' % groupby[0], hit)
+                value = get_value(f'_source.{groupby[0]}', hit)
                 if value in hits_list:
                     hits_list[value].append(hit)
                 else:
@@ -145,8 +145,8 @@ def group_hits(hits, groupby, res=None):
         else:
             for key, val in res.items():
                 for hit in val:
-                    value = get_value('_source.%s' % groupby[0], hit)
-                    tmp_key = '%s / %s' % (key, value)
+                    value = get_value(f'_source.{groupby[0]}', hit)
+                    tmp_key = f'{key} / {value}'
                     if tmp_key in hits_list:
                         hits_list[tmp_key].append(hit)
                     else:


### PR DESCRIPTION
rsync command in redelk-base getremotelogs.sh had incorrect paths mentioned - not taking into account the newly created subdirs for c2-name, e.g. /home/scponly/{cobaltstrike,stage1}/logs. This change fixes this by simply just rsyncing the entire content of /home/scponly on the c2server. Ergo, leaner and fixes a bug.