### PR TITLE
removed outflank.nl as active domain to check

### DIFF
--- a/elkserver/mounts/redelk-config/etc/redelk/redteamdomains.conf
+++ b/elkserver/mounts/redelk-config/etc/redelk/redteamdomains.conf
@@ -6,4 +6,4 @@
 #
 # Author: Outflank B.V. / Marc Smeets
 # 
-outflank.nl
+#outflank.nl


### PR DESCRIPTION
To limit domain checks by default.