### PR TITLE
update logstash to post log4shell version [CVE-2021-44228]

### DIFF
--- a/elkserver/docker/redelk-logstash/Dockerfile
+++ b/elkserver/docker/redelk-logstash/Dockerfile
@@ -7,7 +7,7 @@
 # - Lorenzo Bernardi
 #
 
-FROM docker.elastic.co/logstash/logstash:7.10.0
+FROM docker.elastic.co/logstash/logstash:7.16.1
 LABEL maintainer="Outflank B.V. / Marc Smeets"
 LABEL description="RedELK Logstash"
 


### PR DESCRIPTION
Note that the logstash used did run an up to date java and never appeared to be RCE vulnerable as per: https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476