### PR TITLE
By default turn on alarm backend

### DIFF
--- a/elkserver/mounts/redelk-config/etc/redelk/config.json
+++ b/elkserver/mounts/redelk-config/etc/redelk/config.json
@@ -48,6 +48,10 @@
         "alarm_useragent": {
             "enabled": true,
             "interval": 320
+        },
+        "alarm_backendalarm": {
+            "enabled": true,
+            "interval": 320
         }
     },
     "enrich": {


### PR DESCRIPTION
if 'alarm' as word is seen in backend send an alarm
alarm_backendalarm
