### PR TITLE
Allow admin to set a projectname as prepend in mail-subjects

### DIFF
--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
@@ -36,7 +36,6 @@ if 'tempDir' in data:
 # -- Notifications
 # pylint: disable=invalid-name
 notifications = {
-    'projectname':'redelk-project',
     'email': {
         'enabled': False,
         'smtp': {
@@ -128,3 +127,5 @@ if 'enrich' in data:
 es_connection = ['http://localhost:9200']
 if 'es_connection' in data:
     es_connection = data['es_connection']
+
+project_name = data['project_name'] if 'project_name' in data else 'redelk-project'

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
@@ -36,6 +36,7 @@ if 'tempDir' in data:
 # -- Notifications
 # pylint: disable=invalid-name
 notifications = {
+    'projectname':'redelk-project',
     'email': {
         'enabled': False,
         'smtp': {

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/daemon.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/daemon.py
@@ -125,10 +125,10 @@ def process_alarms(connector_dict, alarm_dict):
             if alarm_status == 'error':
                 logger.warning('Alarm %s did not run correctly, skipping processing (status: %s)', alarm, alarm_status)
                 continue
-            elif alarm_status == 'did_not_run':
+            if alarm_status == 'did_not_run':
                 logger.debug('Alarm %s did not run (this was expected), skipping processing (status: %s)', alarm, alarm_status)
                 continue
-            elif alarm_status == 'unknown':
+            if alarm_status == 'unknown':
                 logger.warning('Alarm %s returned and unknown status (this should never happen), skipping processing (status: %s)', alarm, alarm_status)
                 continue
 

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
@@ -8,6 +8,7 @@ Authors:
 - Outflank B.V. / Mark Bergman (@xychix)
 - Lorenzo Bernardi (@fastlorenzo)
 """
+import os
 import logging
 import smtplib
 import base64
@@ -17,9 +18,8 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formataddr, formatdate
 from json2html import json2html
-import os
 
-from config import notifications
+from config import notifications, project_name
 from modules.helpers import get_value, pprint
 
 
@@ -50,7 +50,7 @@ class Module():
         message = MIMEMultipart()
         # Read html File
         html = mail
-        message['Subject'] = '[%s] %s'%(notifications['projectname'],subject)
+        message['Subject'] = f'[{project_name}] {subject}'
         message['From'] = formataddr((str(Header(from_address, 'utf-8')), from_address))
         message['To'] = ', '.join(to_addresses)
         message['Date'] = formatdate()
@@ -81,7 +81,7 @@ class Module():
         """ Send the alarm """
 
         # Read the RedELK logo from file and base64 encode it
-        with open('%s/redelk_white.png'%FILEDIR, 'rb') as logo_file:
+        with open(f'{FILEDIR}/redelk_white.png', 'rb') as logo_file:
             redelk_logo_b64 = base64.b64encode(logo_file.read()).decode('utf-8')
 
         mail = f'''
@@ -111,7 +111,7 @@ class Module():
                     </tr>
                     <tr>
                         <td bgcolor="#212121" height="20px" style="color: #FAFAFA; font-family: Arial, sans-serif; font-size: 16px; line-height: 20px; padding: 20px 30px 30px 10px;">
-                            Total hits: <em>{alarm["hits"]["total"]}</em>
+                            Project: <em>{project_name}</em><br/>Total hits: <em>{alarm["hits"]["total"]}</em>
                         </td>
                     </tr>
                     <tr>

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
@@ -50,7 +50,7 @@ class Module():
         message = MIMEMultipart()
         # Read html File
         html = mail
-        message['Subject'] = subject
+        message['Subject'] = "[%s] %s"%(notifications['projectname'],subject)
         message['From'] = formataddr((str(Header(from_address, 'utf-8')), from_address))
         message['To'] = ', '.join(to_addresses)
         message['Date'] = formatdate()

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/email/module.py
@@ -50,7 +50,7 @@ class Module():
         message = MIMEMultipart()
         # Read html File
         html = mail
-        message['Subject'] = "[%s] %s"%(notifications['projectname'],subject)
+        message['Subject'] = '[%s] %s'%(notifications['projectname'],subject)
         message['From'] = formataddr((str(Header(from_address, 'utf-8')), from_address))
         message['To'] = ', '.join(to_addresses)
         message['Date'] = formatdate()

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/msteams/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/msteams/module.py
@@ -58,5 +58,5 @@ class Module():  # pylint: disable=too-few-public-methods
         except Exception as error:
             self.logger.exception(error)
 
-        tmsg.title(f'Alarm from {alarm["info"]["name"]} [{alarm["hits"]["total"]} hits]')
+        tmsg.title(f'[{config.project_name}] Alarm from {alarm["info"]["name"]} [{alarm["hits"]["total"]} hits]')
         tmsg.send()

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/requirements.txt
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/requirements.txt
@@ -1,5 +1,5 @@
 json2html==1.3.0
 pymsteams==0.1.14
-elasticsearch==7.10.0
+elasticsearch==7.16.3
 urllib3==1.26.5
 python-dateutil==2.8.2

--- a/elkserver/mounts/redelk-config/etc/redelk/config.json
+++ b/elkserver/mounts/redelk-config/etc/redelk/config.json
@@ -8,9 +8,9 @@
         "le_email": "",
         "staging": "0"
     },
+    "project_name":"redelk-project",
     "es_connection": ["https://elastic:{{ELASTIC_PASSWORD}}@redelk-elasticsearch:9200"],
     "notifications": {
-        "projectname":"redelk-project",
         "email": {
             "enabled": false,
             "smtp": {

--- a/elkserver/mounts/redelk-config/etc/redelk/config.json
+++ b/elkserver/mounts/redelk-config/etc/redelk/config.json
@@ -10,6 +10,7 @@
     },
     "es_connection": ["https://elastic:{{ELASTIC_PASSWORD}}@redelk-elasticsearch:9200"],
     "notifications": {
+        "projectname":"redelk-project",
         "email": {
             "enabled": false,
             "smtp": {


### PR DESCRIPTION
Having multiple RedELKs running parallel one never knows where the alarm came from. With the project name in the mail subject differentiation is easier.