### PR TITLE
xforwardedfor with single IP address not parsed for Nginx

### DIFF
--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/22-filter-redir-nginx_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/22-filter-redir-nginx_logstash.conf
@@ -61,7 +61,7 @@ filter {
     }
 
     # map header values onto dedicated fields and split the values of the headersall field into an array
-    if [redirtraffic.headersall] {
+    if [http][headers][all] {
       # map to dedicated fields
       grok {
         match => { "[http][headers][all]" => [ "(?<[http][headers][useragent]>([^|]*))\|(?<[http][headers][host]>([^|]*))\|(?<[http][headers][x_forwarded_for]>([^|]*))\|(?<[http][headers][x_forwarded_proto]>([^|]*))\|(?<[http][headers][x_host]>([^|]*))\|(?<[http][headers][forwarded]>([^|]*))\|(?<[http][headers][via]>([^|]*))" ] }

--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/22-filter-redir-nginx_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/22-filter-redir-nginx_logstash.conf
@@ -37,7 +37,7 @@ filter {
     # Lines with X-Forwarded-For set. We already filtered out the 'xfordwardedfor:-', so anything left with a large enough log line should be good
     # Optionally match multiple Ips in xforwardedfor, eg. xforwardedfor:1.2.3.4, 2.3.4.5 -> the second IP address (or third or Nth) is an intermediate proxy such as zscaler and will be stored in source.ip_otherproxies
       grok {
-        match => { "messagenosyslog" => [ "frontend:(?<[redir][frontend][name]>([^/]*))/%{IPORHOST:[redir][frontend][ip]}:%{POSINT:[redir][frontend][port]} backend:%{NOTSPACE:[redir][backend][name]} client:%{IPORHOST:[source][cdn][ip]}:%{POSINT:[source][cdn][port]} xforwardedfor:%{IPORHOST:[source][ip]}(?:, )(?:%{GREEDYDATA:[source][ip_otherproxies]}) headers:\{(?<[http][headers][all]>([^\}]*))} statuscode:%{INT:[http][response][status_code]} request:%{GREEDYDATA:[http][request][body][content]}" ] }
+        match => { "messagenosyslog" => [ "frontend:(?<[redir][frontend][name]>([^/]*))/%{IPORHOST:[redir][frontend][ip]}:%{POSINT:[redir][frontend][port]} backend:%{NOTSPACE:[redir][backend][name]} client:%{IPORHOST:[source][cdn][ip]}:%{POSINT:[source][cdn][port]} xforwardedfor:%{IPORHOST:[source][ip]}(?:, )?(?:%{GREEDYDATA:[source][ip_otherproxies]}) headers:\{(?<[http][headers][all]>([^\}]*))} statuscode:%{INT:[http][response][status_code]} request:%{GREEDYDATA:[http][request][body][content]}" ] }
         add_tag => [ "redirtrafficxforwardedfor" ]
       }
         # remove field [source][ip_otherproxies] if empty


### PR DESCRIPTION
Hi

The existing logstash grok for HTTP request with `xforwardfor` header works well for multiple IP addresses but not for a single IP address as shown below. The likely cause is the space in `(?:, )` is not made optional. Proposed fix is change `xforwardedfor:%{IPORHOST:[source][ip]}(?:, )` to `xforwardedfor:%{IPORHOST:[source][ip]}(?:, )?`. 

### Multiple IP addresses in xforwardedfor sample request parsed successfully
![image](https://user-images.githubusercontent.com/9748813/157744250-1882271f-d20c-4754-8d3b-82761391ead8.png)

### Single IP addresses in xforwardedfor sample request parsed unsuccessfully 
![image](https://user-images.githubusercontent.com/9748813/157744347-8249a4df-c7d0-4a30-912e-094e15ec41fa.png)

### Modified grok 
Original 
```
frontend:(?<[redir][frontend][name]>([^/]*))/%{IPORHOST:[redir][frontend][ip]}:%{POSINT:[redir][frontend][port]} backend:%{NOTSPACE:[redir][backend][name]} client:%{IPORHOST:[source][cdn][ip]}:%{POSINT:[source][cdn][port]} xforwardedfor:%{IPORHOST:[source][ip]}(?:, )(?:%{GREEDYDATA:[source][ip_otherproxies]}) headers:\{(?<[http][headers][all]>([^\}]*))} statuscode:%{INT:[http][response][status_code]} request:%{GREEDYDATA:[http][request][body][content]}
```
To
```
frontend:(?<[redir][frontend][name]>([^/]*))/%{IPORHOST:[redir][frontend][ip]}:%{POSINT:[redir][frontend][port]} backend:%{NOTSPACE:[redir][backend][name]} client:%{IPORHOST:[source][cdn][ip]}:%{POSINT:[source][cdn][port]} xforwardedfor:%{IPORHOST:[source][ip]}(?:, )?(?:%{GREEDYDATA:[source][ip_otherproxies]}) headers:\{(?<[http][headers][all]>([^\}]*))} statuscode:%{INT:[http][response][status_code]} request:%{GREEDYDATA:[http][request][body][content]}
```
![image](https://user-images.githubusercontent.com/9748813/157744427-18e7c2f1-59e6-463c-97dc-12ab7d94dfc6.png)

Also made the following change as there is no [redirtraffic.headersall] in the configuration.

`if [redirtraffic.headersall] {` to `if [http][headers][all] {`
