### PR TITLE
Apache logstash filter bug and typos

### DIFF
--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/20-filter-redir-haproxy_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/20-filter-redir-haproxy_logstash.conf
@@ -200,7 +200,7 @@ filter {
         remove_field => [ "tmpgeoip" ]
       }
     }
-    # Add data to the redirtraffic.sourceipcdn
+    # Add data to source.cdn.ip
     if [source][cdn][ip] {
       # duplicate field so we can replace it with reverse DNS lookup
       mutate {

--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/21-filter-redir-apache_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/21-filter-redir-apache_logstash.conf
@@ -37,7 +37,7 @@ filter {
     # Lines with X-Forwarded-For set. We already filtered out the 'xfordwardedfor:-', so anything left with a large enough log line should be good
     # Optionally match multiple Ips in xforwardedfor, eg. xforwardedfor:1.2.3.4, 2.3.4.5 -> the second IP address (or third or Nth) is an intermediate proxy such as zscaler and will be stored in source.ip_otherproxies
       grok {
-        match => { "messagenosyslog" => [ "frontend:(?<[redir][frontend][name]>([^/]*))/%{IPORHOST:[redir][frontend][ip]}:%{POSINT:[redir][frontend][port]} backend:%{NOTSPACE:[redir][backend][name]} client:%{IPORHOST:[source][cdn][ip]}:%{POSINT:[source][cdn][port]} xforwardedfor:%{IPORHOST:[source][ip]}(?:, )(?:%{GREEDYDATA:[source][ip_otherproxies]}) headers:\{(?<[http][headers][all]>([^\}]*))} statuscode:%{INT:[http][response][status_code]} request:%{GREEDYDATA:[http][request][body][content]}" ] }
+        match => { "messagenosyslog" => [ "frontend:(?<[redir][frontend][name]>([^/]*))/%{IPORHOST:[redir][frontend][ip]}:%{POSINT:[redir][frontend][port]} backend:%{NOTSPACE:[redir][backend][name]} client:%{IPORHOST:[source][cdn][ip]}:%{POSINT:[source][cdn][port]} xforwardedfor:%{IPORHOST:[source][ip]}(?:, )?(?:%{GREEDYDATA:[source][ip_otherproxies]}) headers:\{(?<[http][headers][all]>([^\}]*))} statuscode:%{INT:[http][response][status_code]} request:%{GREEDYDATA:[http][request][body][content]}" ] }
         add_tag => [ "redirtrafficxforwardedfor" ]
       }
         # remove field [source][ip_otherproxies] if empty
@@ -61,10 +61,10 @@ filter {
     }
 
     # map header values onto dedicated fields and split the values of the headersall field into an array
-    if [redirtraffic.headersall] {
+    if [http][headers][all] {
       # map to dedicated fields
       grok {
-        match => { "redirtraffic.headersall" => [ "(?<[http][headers][useragent]>([^|]*))\|(?<[http][headers][host]>([^|]*))\|(?<[http][headers][x_forwarded_for]>([^|]*))\|(?<[http][headers][x_forwarded_proto]>([^|]*))\|(?<[http][headers][x_host]>([^|]*))\|(?<[http][headers][forwarded]>([^|]*))\|(?<[http][headers][via]>([^|]*))" ] }
+        match => { "[http][headers][all]" => [ "(?<[http][headers][useragent]>([^|]*))\|(?<[http][headers][host]>([^|]*))\|(?<[http][headers][x_forwarded_for]>([^|]*))\|(?<[http][headers][x_forwarded_proto]>([^|]*))\|(?<[http][headers][x_host]>([^|]*))\|(?<[http][headers][forwarded]>([^|]*))\|(?<[http][headers][via]>([^|]*))" ] }
       }
 
       # split the values into an array

--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/21-filter-redir-apache_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/21-filter-redir-apache_logstash.conf
@@ -149,7 +149,7 @@ filter {
       }
     }
 
-    # Add data to the redirtraffic.sourceipcdn
+    # Add data to source.cdn.ip
     if [source][cdn][ip] {
       # duplicate field so we can replace it with reverse DNS lookup
       mutate {

--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/22-filter-redir-nginx_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/22-filter-redir-nginx_logstash.conf
@@ -148,7 +148,7 @@ filter {
       }
     }
 
-    # Add data to the redirtraffic.sourceipcdn
+    # Add data to source.cdn.ip
     if [source][cdn][ip] {
       # duplicate field so we can replace it with reverse DNS lookup
       mutate {


### PR DESCRIPTION
Fixed:
- apache logstash filter bug of single IP in xforwardedfor (same as #246 for Nginx)
- apache logstash filter bug of [http][headers][all] (same as #246 for Nginx)
- fixed a few typos in logstash filters