### PR TITLE
Permission and Implant Log URL issue

### DIFF
--- a/elkserver/docker/redelk-base/redelkinstalldata/42_redelk-base-docker-init.sh
+++ b/elkserver/docker/redelk-base/redelkinstalldata/42_redelk-base-docker-init.sh
@@ -69,7 +69,7 @@ echo "" >> $LOGFILE
 
 # Set relevant permissions for redelk user
 echo "[*] Setting dir permisisons for redelk user" | tee -a $LOGFILE
-chown -Rv redelk /var/log/redelk/ && chown -Rv www-data:redelk /var/www/html/c2logs && chown -Rv redelk /etc/redelk && chmod 775 /var/www/html/c2logs >> $LOGFILE 2>&1
+chown -Rv redelk /var/log/redelk/ && chown -Rv redelk:www-data /var/www/html/c2logs && chown -Rv redelk /etc/redelk && chmod 2755 /var/www/html/c2logs >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
     echo "[X] Could not set dir permissions for redelk user (Error Code: $ERROR)."

--- a/elkserver/install-elkserver.sh
+++ b/elkserver/install-elkserver.sh
@@ -483,6 +483,13 @@ if [ ${WHATTOINSTALL} = "full" ]; then
     fi
 fi
 
+echo "[*] Setting permissions on redelk base cron job" | tee -a $LOGFILE
+chmod 600 ./mounts/redelk-config/etc/cron.d/redelk >> $LOGFILE 2>&1
+ERROR=$?
+if [ $ERROR -ne 0 ]; then
+    echo "[X] Could not set permissions on redelk base cron (Error Code: $ERROR)." | tee -a $LOGFILE
+fi
+
 echo "[*] Setting permissions on logstash configs" | tee -a $LOGFILE
 chown -R 1000 ./mounts/logstash-config/* >> $LOGFILE 2>&1
 ERROR=$?

--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/51-filter-c2-cobaltstrike_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/51-filter-c2-cobaltstrike_logstash.conf
@@ -65,11 +65,6 @@ filter {
     # Parsed by filebeat as c2.log.type:beacon
     # 
     if [c2][log][type] == "beacon" {
-      # Add path/URI value to the full beacon.log file
-      ruby {
-        path => "/usr/share/logstash/redelk-main/scripts/cs_makebeaconlogpath.rb"
-      }
-
       # Set the beacon id from the file name
       # Need to match for 3 different occurence:
       #  - one where it states 'unknown'.
@@ -82,6 +77,11 @@ filter {
           "/cobaltstrike/logs/((\d{6}))/unknown/(beacon|ssh)_(?<[implant][id]>(\d{1,10}))",
           "/cobaltstrike/logs/((\d{6}))/%{IPORHOST:[host][ip_int]}/(beacon|ssh)_(?<[implant][id]>(\d{1,10}))"
         ] }
+      }
+      
+      # Add path/URI value to the full beacon.log file
+      ruby {
+        path => "/usr/share/logstash/redelk-main/scripts/cs_makebeaconlogpath.rb"
       }
 
       # matching lines like: [metadata] 1.2.3.4 <- 10.10.10.10; computer: SomeComputername; user: SomeUsername; pid: 7368; os: Windows; version: 6.1; beacon arch: x86


### PR DESCRIPTION
It's important to ensure `[log][file][path]` is groked before `cs_makebeaconlogpath.rb` , otherwise there will be a misalignment between the Implant URL, `[implant][log_file]` and `[log][file][path]` for beacons that are running for multiple days as the `[log][file][path]` will take the value from where the beacon was first established as shown below.
```
"implant.log_file": [
      "/c2logs/CS/cobaltstrike/logs/220516/x.x.x.x/beacon_1223281090.log"
    ],
    "log.file.path": [
        "/opt/cobaltstrike/logs/220603/x.x.x.x/beacon_1223281090.log"
    ],
```

I also have issue, accessing the beacon logs via Kibana due to permission issues, and prior to this, I solved it by adding a cron job that does `chown` every min which is messy. By making `the /var/www/html/cslog` folder owned by `redelk:www-data`  would make more sense since only `redelk` is making changing to the folders and SGID is set to propagate www-data group ownership for files created subsequently without having to chmod/chown down the road.. 

Lastly I had issue with the RedELK cron job not activating in redelk-base due to permissive file permission and I changed it to 600 to make sure only the file owner can make changes to it. 