### PR TITLE
Alarm manual

### DIFF
--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/config.py
@@ -82,6 +82,10 @@ alarms = {
     'alarm_dummy': {
         'enabled': False,
         'interval': 300
+    },
+    'alarm_manual': {
+        'enabled': False,
+        'interval': 300
     }
 }
 if 'alarms' in data:

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_manual/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_manual/module.py
@@ -40,7 +40,7 @@ class Module():
         self.logger.info('finished running module. result: %s hits', ret['hits']['total'])
         return ret
 
-    def get_alarmed_messages(self):  # pylint: disable=no-self-use
+    def get_alarmed_messages(self): 
         """ Returns all previous messages that have been alarmed already """
         es_query = {
             'sort': [{'@timestamp': {'order': 'desc'}}],
@@ -77,8 +77,6 @@ class Module():
 
         return messages
 
-    def alarm_check(self, alarmed_messages):  # pylint: disable=no-self-use
-        """ This check queries for C2 messages that contain 'REDELK_ALARM' """
     def alarm_check(self, alarmed_messages): 
         """ This check queries for C2 messages (input of eventlog) that contain 'REDELK_ALARM' """
         es_query = {
@@ -123,7 +121,3 @@ class Module():
 
         # Return the array of new documents to be alarmed
         return hits
-
-
-
-

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_manual/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_manual/module.py
@@ -4,7 +4,7 @@ Part of RedELK
 
 This check queries for C2 messages that contain "REDELK_ALARM" and will send an alarm with the content of that line.
 
-Only alarms when c2.log.type is: events or implant_output
+Only alarms when c2.log.type is: events or implant_input
 
 Authors:
 - Outflank B.V. / Marc Smeets (@MarcOverIp)
@@ -17,7 +17,7 @@ from modules.helpers import get_initial_alarm_result, get_value, raw_search
 info = {
     'version': 0.1,
     'name': 'Alarm manual module',
-    'description': 'This check queries c2.message items that contain "REDELK_ALARM" and alarms the content of that line',
+    'description': 'This check queries c2.message items (output and event log) that contain "REDELK_ALARM" and alarms the content of that line',
     'type': 'redelk_alarm',
     'submodule': 'alarm_manual'
 }
@@ -79,13 +79,15 @@ class Module():
 
     def alarm_check(self, alarmed_messages):  # pylint: disable=no-self-use
         """ This check queries for C2 messages that contain 'REDELK_ALARM' """
+    def alarm_check(self, alarmed_messages): 
+        """ This check queries for C2 messages (input of eventlog) that contain 'REDELK_ALARM' """
         es_query = {
             'sort': [{'@timestamp': {'order': 'asc'}}],
             'query': {
                 'bool': {
                     'must': {
                         'query_string': {
-                            'query': '(c2.message:*REDELK_ALARM*) AND (c2.log.type:implant_output OR c2.log.type:events)'
+                            'query': '(c2.message:*REDELK_ALARM*) AND (((c2.log.type:implant_input) AND (tags:enrich_*)) OR (c2.log.type:events))'
                         }
                     },
                     'must_not': [

--- a/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_manual/module.py
+++ b/elkserver/docker/redelk-base/redelkinstalldata/scripts/modules/alarm_manual/module.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python3
+"""
+Part of RedELK
+
+This check queries for C2 messages that contain "REDELK_ALARM" and will send an alarm with the content of that line.
+
+Only alarms when c2.log.type is: events or implant_output
+
+Authors:
+- Outflank B.V. / Marc Smeets (@MarcOverIp)
+- Lorenzo Bernardi (@fastlorenzo)
+"""
+import logging
+
+from modules.helpers import get_initial_alarm_result, get_value, raw_search
+
+info = {
+    'version': 0.1,
+    'name': 'Alarm manual module',
+    'description': 'This check queries c2.message items that contain "REDELK_ALARM" and alarms the content of that line',
+    'type': 'redelk_alarm',
+    'submodule': 'alarm_manual'
+}
+
+class Module():
+    """ Alarm manual module """
+    def __init__(self):
+        self.logger = logging.getLogger(info['submodule'])
+
+    def run(self):
+        """ Run the alarm module """
+        ret = get_initial_alarm_result()
+        ret['info'] = info
+        ret['fields'] = ['@timestamp', 'c2.message', 'agent.name', 'c2.log.type', 'host.name', 'user.name', 'host.ip']
+        ret['groupby'] = ['@timestamp']
+        alarmed_messages = self.get_alarmed_messages()
+        report = self.alarm_check(alarmed_messages)
+        ret['hits']['hits'] = report
+        ret['hits']['total'] = len(report)
+        self.logger.info('finished running module. result: %s hits', ret['hits']['total'])
+        return ret
+
+    def get_alarmed_messages(self):  # pylint: disable=no-self-use
+        """ Returns all previous messages that have been alarmed already """
+        es_query = {
+            'sort': [{'@timestamp': {'order': 'desc'}}],
+            'query': {
+                'bool': {
+                    'filter': [
+                        {
+                            'range':  {
+                                '@timestamp': {
+                                    'gte': 'now-1y'
+                                }
+                            }
+                        },
+                        {'match': {'tags': info['submodule']}}
+                    ]
+                }
+            }
+        }
+        res = raw_search(es_query, index='rtops-*')
+        if res is None:
+            alarmed_hits = []
+        else:
+            alarmed_hits = res['hits']['hits']
+
+        # Created a dict grouped by c2 message (from c2.message)
+        messages = {}
+        for alarmed_hit in alarmed_hits:
+            # pylint: disable=invalid-name
+            message = get_value('_source.c2.message', alarmed_hit)
+            if message in messages:
+                messages[message].append(alarmed_hit)
+            else:
+                messages[message] = [alarmed_hit]
+
+        return messages
+
+    def alarm_check(self, alarmed_messages):  # pylint: disable=no-self-use
+        """ This check queries for C2 messages that contain 'REDELK_ALARM' """
+        es_query = {
+            'sort': [{'@timestamp': {'order': 'asc'}}],
+            'query': {
+                'bool': {
+                    'must': {
+                        'query_string': {
+                            'query': '(c2.message:*REDELK_ALARM*) AND (c2.log.type:implant_output OR c2.log.type:events)'
+                        }
+                    },
+                    'must_not': [
+                        {'match': {'tags': info['submodule']}}
+                    ]
+                }
+            }
+        }
+        res = raw_search(es_query, index='rtops-*')
+        if res is None:
+            not_enriched_hits = []
+        else:
+            not_enriched_hits = res['hits']['hits']
+
+        # Created a dict grouped by c2 messages (from c2.message)
+        messages = {}
+        for not_enriched in not_enriched_hits:
+            # pylint: disable=invalid-name
+            message = get_value('_source.c2.message', not_enriched)
+            if message in messages:
+                messages[message].append(not_enriched)
+            else:
+                messages[message] = [not_enriched]
+
+        hits = []
+
+        # Now we check if the C2 messages have already been alarmed in the past timeframe defined in the config
+        # pylint: disable=invalid-name
+        for message, message_val in messages.items():
+            # Not alarmed yet, process it
+            if message not in alarmed_messages:
+                hits += message_val
+
+        # Return the array of new documents to be alarmed
+        return hits
+
+
+
+

--- a/elkserver/mounts/redelk-config/etc/redelk/config.json
+++ b/elkserver/mounts/redelk-config/etc/redelk/config.json
@@ -53,6 +53,10 @@
         "alarm_backendalarm": {
             "enabled": true,
             "interval": 320
+        },
+        "alarm_manual": {
+            "enabled": false,
+            "interval": 300
         }
     },
     "enrich": {


### PR DESCRIPTION
PR for issue #138 

One bug left: I want the fields ``host.name``, ``user.name`` and ``host.ip`` are included in the returned alarm data. But these fields aren't filled with data, even when the actual event does have these fields.