### PR TITLE
Basic sanity check of openssl config file in initial install script

### DIFF
--- a/initial-setup.sh
+++ b/initial-setup.sh
@@ -42,6 +42,15 @@ if [  ! -f $1 ];then
     exit 1
 fi >> $LOGFILE 2>&1
 
+
+echo "[*] Doing basic sanity check of openssl config file." | tee -a $LOGFILE
+grep -E "MODIFYME|dnsnameofyourredelkserver|someseconddnsname" $1 | grep -v "^#" >> $LOGFILE 2>&1
+ERROR=$?
+if [ $ERROR -ne 0 ]; then
+    echoerror "[X] Check your openssl config file, it fails basic sanity checks. (Error Code: $ERROR)."
+    exit 1
+fi
+
 echo ""
 echo "[*] Will generate TLS certificates for the following DNS names and/or IP addresses:" | tee -a $LOGFILE
 grep -E "^DNS\.|^IP\." certs/config.cnf

--- a/initial-setup.sh
+++ b/initial-setup.sh
@@ -44,7 +44,7 @@ fi >> $LOGFILE 2>&1
 
 
 echo "[*] Doing basic sanity check of openssl config file." | tee -a $LOGFILE
-grep -E "MODIFYME|dnsnameofyourredelkserver|someseconddnsname" $1 | grep -v "^#" >> $LOGFILE 2>&1
+grep -E "MODIFYME|dnsnameofyourredelkserver|someseconddnsname|123.123.123.123" $1 | grep -v "^#" >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
     echoerror "[X] Check your openssl config file, it fails basic sanity checks. (Error Code: $ERROR)."


### PR DESCRIPTION
Basic check in initial-install.sh to validate the openssl config file. It checks if one of the following is found:

- the by default present string `MODIFYME` in an uncommented line
- the by default present string `dnsnameofyourredelkserver` in an uncommented line
- the by default present string `someseconddnsname` in an uncommented line
- the by default present string `123.123.123.123` in an uncommented line

The install script aborts when one of these is found.