### PR TITLE
Added filebeat configuration for Havoc C2 logs

### DIFF
--- a/c2servers/filebeat/inputs.d/filebeat_havoc.yml
+++ b/c2servers/filebeat/inputs.d/filebeat_havoc.yml
@@ -11,7 +11,7 @@
     max_lines: 500
   fields:
     infra:
-      attack_scenario: @@ATTACKSCENARIO@@
+      attack_scenario: shorthaul
       log:
         type: rtops
     c2:
@@ -31,17 +31,17 @@
   fields_under_root: true
   fields:
     infra:
-      attack_scenario: @@ATTACKSCENARIO@@
-    log:
-      type: rtops
+      attack_scenario: shorthaul
+      log:
+        type: rtops
     c2:
       program: havoc
       log:
         type: teamserver
   multiline:
     pattern: '^\[\d{2}:\d{2}:\d{2}\]'
-    negate: false
-    match: pattern
+    negate: true
+    match: after
   processors:
     - dissect:
         tokenizer: '[%{timestamp}] [%{log_level}] %{message}'
@@ -52,7 +52,7 @@
           not:
             or:
               - regexp:
-                  teamserver.message: "User .*"
+                  teamserver.message: "User *"
               - regexp:
-                  teamserver.message: "Started .* listener.*"
+                  teamserver.message: "Started .* listener*"
 

--- a/c2servers/filebeat/inputs.d/filebeat_havoc.yml
+++ b/c2servers/filebeat/inputs.d/filebeat_havoc.yml
@@ -1,0 +1,58 @@
+- type: log
+  scan_frequency: 5s
+  enabled: true
+  fields_under_root: true
+  paths:
+    - /opt/Havoc/data/loot/*/agents/*/Console_*.log
+  multiline:
+    pattern: '^\[Time:'
+    negate: true
+    match: after
+    max_lines: 500
+  fields:
+    infra:
+      attack_scenario: @@ATTACKSCENARIO@@
+      log:
+        type: rtops
+    c2:
+      program: havoc
+      log:
+        type: agent_console
+  processors:
+    - dissect:
+        tokenizer: '[Time: %{timestamp}] [User: %{user.name}] [TaskID: %{taskid}] %{c2.message}'
+        field: "message"
+        target_prefix: ""
+
+- type: log
+  enabled: true
+  paths:
+    - /opt/Havoc/data/loot/*/teamserver.log
+  fields_under_root: true
+  fields:
+    infra:
+      attack_scenario: @@ATTACKSCENARIO@@
+    log:
+      type: rtops
+    c2:
+      program: havoc
+      log:
+        type: teamserver
+  multiline:
+    pattern: '^\[\d{2}:\d{2}:\d{2}\]'
+    negate: false
+    match: pattern
+  processors:
+    - dissect:
+        tokenizer: '[%{timestamp}] [%{log_level}] %{message}'
+        field: "message"
+        target_prefix: "teamserver"
+    - drop_event:
+        when:
+          not:
+            or:
+              - regexp:
+                  teamserver.message: "User .*"
+              - regexp:
+                  teamserver.message: "Started .* listener.*"
+


### PR DESCRIPTION
This pull request adds a basic Filebeat configuration (filebeat_havoc.yml) for capturing logs from the Havoc C2 (https://github.com/HavocFramework/Havoc)
- Captures logs from agent consoles located at /opt/Havoc/data/loot/*/agents/*/Console_*.log.
- Captures logs from the teamserver located at /opt/Havoc/data/loot/*/teamserver.log