### PR TITLE
Adds support for ECS compliant cloning

### DIFF
--- a/elkserver/mounts/logstash-config/redelk-main/conf.d/99-outputs_logstash.conf
+++ b/elkserver/mounts/logstash-config/redelk-main/conf.d/99-outputs_logstash.conf
@@ -25,7 +25,7 @@ output {
     }
   }
 
-  if [type] == "implantsdb" {
+  if ([type] == "implantsdb" or "implantsdb" in [tags]) {
     elasticsearch {
       hosts => ["redelk-elasticsearch:9200"]
       sniffing => false
@@ -73,7 +73,7 @@ output {
     }
   }
 
-  if [type] == "bluecheck" {
+  if ([type] == "bluecheck" or "bluecheck" in [tags]) {
     elasticsearch {
       hosts => ["redelk-elasticsearch:9200"]
       sniffing => false


### PR DESCRIPTION
When using the clone filter with logstash in ECS complaint mode, [type] is no longer created, instead the clones value(s) are instead added as tags to the cloned documents. This change implements a simple or conditional where the cloned values are also checked against the set tags.